### PR TITLE
security: lock down prod Prisma migration workflow

### DIFF
--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -1,16 +1,15 @@
 name: Prisma Migrate
 
 on:
-  push:
-    branches:
-      - 'main'
-    paths:
-      - 'prisma/**'
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   migrate:
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

TanStack の npm 供給チェーン攻撃 ([incident followup](https://tanstack.com/blog/incident-followup)) を踏まえた Phase 1 の応急対応。本リポジトリの `migration.yml` は `main` への push で本番DBへ自動マイグレーションを実行しており、攻撃時の pivot point になりうるため、以下を変更します。

- `on: push` トリガーを撤去し、`workflow_dispatch` のみに（本番マイグレーションは明示的な手動実行を必須に）
- ジョブを `production` Environment に紐付け（reviewer 必須・protected branch のみデプロイ許可、サーバ側で設定済み）
- workflow スコープで `permissions: contents: read` を明示し、GITHUB_TOKEN を最小権限化

## Why now

- 現状 `main` に branch protection の required_reviews が無いため、不正な PR が誤ってマージされた瞬間に `PROD_DATABASE_URL` を保持したジョブが走る経路がある
- 依存パッケージが侵害 → postinstall → シークレット窃取 という TanStack と同型の経路でも、自動トリガーは攻撃面を広げる
- マイグレーション頻度を考えると、人手承認のコストより安全性のリターンが大きい

## Server-side changes already applied (out of PR scope)

- `Production` Environment に required_reviewers (RyoSogawa) と `deployment_branch_policy.protected_branches: true` を設定済み

## Test plan

- [ ] PR マージ後、`Actions > Prisma Migrate > Run workflow` から手動実行できることを確認
- [ ] 実行時に Environment レビュー待ち状態になることを確認
- [ ] レビュー承認後にマイグレーションが完走することを確認
- [ ] `prisma/**` を変更した PR をマージしても自動実行されないことを確認

## Follow-ups (別 PR)

- main ブランチに branch protection (required_reviews ≥ 1, required_status_checks) を設定
- Actions の SHA pinning
- `PROD_DATABASE_URL` を repository secret から Environment secret に移管（権限境界の明確化）