### PR TITLE
fix: resolve no-unsafe-argument errors in createSupabaseServerClient

### DIFF
--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -4,8 +4,11 @@ import { env } from '@/env';
 
 import type { cookies } from 'next/headers';
 
+type CookieStore = Awaited<ReturnType<typeof cookies>>;
+type CookieSetArgs = Parameters<CookieStore['set']>;
+
 export const createSupabaseServerClient = (
-  cookieStore: Awaited<ReturnType<typeof cookies>>,
+  cookieStore: CookieStore,
   supabaseAccessToken?: string,
 ) => {
   return createServerClient(env.NEXT_PUBLIC_SUPABASE_URL, env.SUPABASE_ANON_KEY, {
@@ -20,7 +23,7 @@ export const createSupabaseServerClient = (
       },
       set(name: string, value: string, options: CookieOptions) {
         try {
-          cookieStore.set({ name, value, ...options });
+          cookieStore.set(...([{ name, value, ...options }] as CookieSetArgs));
         } catch {
           // The `set` method was called from a Server Component.
           // This can be ignored if you have middleware refreshing
@@ -29,7 +32,7 @@ export const createSupabaseServerClient = (
       },
       remove(name: string, options: CookieOptions) {
         try {
-          cookieStore.set({ name, value: '', ...options });
+          cookieStore.set(...([{ name, value: '', ...options }] as CookieSetArgs));
         } catch {
           // The `delete` method was called from a Server Component.
           // This can be ignored if you have middleware refreshing


### PR DESCRIPTION
## Summary

ESLint v9 flat config 移行 (`6ba95fc`) 以降、`src/utils/supabase.ts` で `@typescript-eslint/no-unsafe-argument` エラーが 2 件発生しており CI (lint job) と Vercel Preview build が継続的に失敗していた。本 PR でこれを解消する。

## Root cause

`cookieStore.set({ name, value, ...options })` の呼び出しで、`set` メソッドのオーバーロードシグネチャ:

```
[key: string, value: string, cookie?: Partial<ResponseCookie>] | [options: ResponseCookie]
```

に対して `{ name, value, ...options }` の型が解決しきれず、第 1 引数が `any` 推論となり `no-unsafe-argument` ルールに引っかかっていた。

## Fix

`cookies()` の戻り型から `set` メソッドの引数 tuple 型を取り出し、スプレッド呼び出しで明示的にキャスト:

```ts
type CookieStore = Awaited<ReturnType<typeof cookies>>;
type CookieSetArgs = Parameters<CookieStore['set']>;
// ...
cookieStore.set(...([{ name, value, ...options }] as CookieSetArgs));
```

- @supabase/ssr が期待するオブジェクト引数形式を温存
- ランタイム挙動は変えず、型情報のみ補強
- `Parameters<>` を使うことで、Next.js 側のシグネチャ変更にも追従しやすい

## Test plan

- [x] `pnpm lint` がローカルで exit 0 (errors: 0)
- [ ] CI lint job が緑
- [ ] Vercel Preview build が緑 (env vars が Preview スコープに設定されていれば)
- [ ] 動作回帰: ログイン → ログアウト → セッション再取得で cookie が正しく書き込まれる

## Context

これは [security/restrict-prod-migration-workflow #3](https://github.com/RyoSogawa/iikane-palette-keion-app/pull/3) が初めて CI を回した結果、main 側の既存問題として発覚したもの。本 PR を先にマージすると #3 を rebase して緑化できる。